### PR TITLE
feature-fix_osx_gcc_eval

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -16,7 +16,7 @@ set -e
 # if either of the conditions are met, install dev tools
 if [[ $(/usr/bin/gcc 2>&1) =~ "no developer tools were found" ]] || [[ ! -x /usr/bin/gcc ]]; then
     echo "Info   | Install   | xcode"
-    eval xcode-select --install
+    xcode-select --install
 fi
 
 # Download and install Homebrew


### PR DESCRIPTION
Added some logic to evaluate the output of gcc, in order to support vanilla macbooks. This addresses the issue of of xcode not being installed due to gcc existing on osx by default but is really a misnomer. 

Vanilla GCC output from os x mavericks: 

$ gcc
xcode-select: note: no developer tools were found at '/Applications/Xcode.app', requesting install. Choose an option in the dialog to download the command line developer tools
